### PR TITLE
Ensure doctor/patient toggle works from home page to card

### DIFF
--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -78,13 +78,9 @@ class HomePage extends React.Component {
                         />
                         <div className="role">{isPatient === true ? 'No' : 'Yes'}</div>
                     </div>
-
                     <div>
                         <div className="go-button" onClick={() => this.goToSurvey()}>Go</div>
                     </div>
-
-                    
-
                     <div className="home-page-blurb">
                         <div className="blurb-copy">
                             Personalized cancer survival rates from the experts at <a className="weight-700" href="http://courage.health" target="_blank">Courage Health</a>

--- a/src/SurveyPage.js
+++ b/src/SurveyPage.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import React from 'react'
 
 import Card from './Card'
@@ -12,20 +13,21 @@ import QuestionDrawer from './QuestionDrawer'
 class SurveyPage extends React.Component {
     constructor (props) {
         super(props)
-        const historyState = this.props.history.location.state || {}
+        const isPatient = _.get(props, 'history.location.state.isPatient', true)
+        const selectedCancerType = _.get(props, 'history.location.state.selectedCancerType', 'liver')
         this.state = {
             age: 30,
             diagnosed: 3, // Assuming this is time since diagnosis in months.
             grade: '1',
-            isPatient: historyState.isPatient || true,
+            isPatient,
             rate: null,
-            selectedCancerType: historyState.selectedCancerType || 'liver',
+            selectedCancerType,
             sex: null,
             stage: '1',
         }
     }
 
-    componentDidMount = () => {
+    componentDidMount () {
         this.calculateCsr()
     }
 


### PR DESCRIPTION
This pull request fixes a bug that prevented the user’s selection (doctor or patient) from the home page from being carried over to the card when they clicked the “go” button.