### PR TITLE
iOS Select Element Centering Fix

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang='en'>
   <head>
     <meta charset='utf-8'>
-    <meta name='viewport' content='width=device-width, initial-scale=1'>
+    <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'>
     <link rel='shortcut icon' href='%PUBLIC_URL%/favicon.ico'>
     <!--
       Notice the use of %PUBLIC_URL% in the tag above.

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -22,15 +22,19 @@ class Dropdown extends React.Component {
 
         if (isMobile) {
             return (
-                <select
-                    className={combinedClassName}
-                    defaultValue={selectedItem}
-                    onChange={event => this.selectItem(event.target.value)}
-                >
-                    {list.map((item, i) => {
-                        return <option key={i} value={item}>{item}</option>
-                    })}
-                </select>
+                <div className="mobile-dropdown-container relative">
+                    <br />
+                    <div className="mobile-dropdown">{selectedItem}</div>
+                    <select
+                        className={combinedClassName}
+                        defaultValue={selectedItem}
+                        onChange={event => this.selectItem(event.target.value)}
+                    >
+                        {list.map((item, i) => {
+                            return <option key={i} value={item}>{item}</option>
+                        })}
+                    </select>
+                </div>
             )
         }
         return (

--- a/src/styles/dropdown.css
+++ b/src/styles/dropdown.css
@@ -53,3 +53,41 @@
     margin-top: .15em;
     fill: #bbb;
 }
+@supports (-webkit-overflow-scrolling: touch) {
+    .mobile-dropdown-container {
+        position: relative;
+        width: 100%;
+    }
+    .dropdown {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        width: 100%;
+        height: 100%;
+        display: block;
+        opacity: 0.001;
+        z-index: 100;
+    }
+    .mobile-dropdown {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        width: 100%;
+        height: 100%;
+        display: block;
+        text-align: center;
+        z-index: 99;
+    }
+    .mobile-dropdown::after {
+        content: '  ▾';
+    }
+}
+@supports not (-webkit-overflow-scrolling: touch) {
+    .mobile-dropdown {
+        display: none;
+    }
+}


### PR DESCRIPTION
I've created a way for you to center the `<select>` control and still have the native picker.

Instead of displaying the currently selected item using the `<select>` button, I'm instead showing the currently selected item with a normal `<div>`, then placing the `<select>` control atop the `<div>` but making it very very transparent. This means the `<select>` control takes the click (or in this case, tap) event, but you can't see it.

The `<div>` element instead is eminently more stylable. I've even added an arrow icon with CSS so you don't have to lose that on mobile either.

This hack shouldn't appear on desktop browsers.