### PR TITLE
Hide certain questions from patient view

### DIFF
--- a/src/QuestionDrawer.js
+++ b/src/QuestionDrawer.js
@@ -13,7 +13,7 @@ import QuestionStage from './QuestionStage'
 
 class QuestionDrawer extends React.Component {
     render () {
-        const { changeValue, selectedCancerType, userData } = this.props
+        const { changeValue, isPatient, selectedCancerType, userData } = this.props
         const { age, diagnosed, grade, sex, stage } = userData
         const selectedCancer = _.find(CancerTypes, { id: selectedCancerType })
         const color = _.get(selectedCancer, 'colors.[0]', 'black')
@@ -72,16 +72,22 @@ class QuestionDrawer extends React.Component {
                         diagnosed={diagnosed}
                     />
                 }
-                {extraVariables && extraVariables.map((extraVariable, e) => (
-                    <QuestionCustom
-                        changeValue={changeValue}
-                        className="variable-row"
-                        color={color}
-                        key={e}
-                        userData={userData}
-                        variable={extraVariable}
-                    />
-                ))}
+                {extraVariables && extraVariables.map((extraVariable, e) => {
+                    const shouldShowExtraVariableToPatient = extraVariable.showToPatient === true && isPatient === true
+                    if (!isPatient || shouldShowExtraVariableToPatient) {
+                        return (
+                            <QuestionCustom
+                                changeValue={changeValue}
+                                className="variable-row"
+                                color={color}
+                                key={e}
+                                userData={userData}
+                                variable={extraVariable}
+                            />
+                        )
+                    }
+                    return null
+                })}
             </div>
         )
     }

--- a/src/SurveyPage.js
+++ b/src/SurveyPage.js
@@ -152,6 +152,7 @@ class SurveyPage extends React.Component {
                     <div className={questionDrawerContainerClassName}> 
                         <QuestionDrawer
                             changeValue={this.changeValue}
+                            isPatient={isPatient}
                             selectedCancerType={selectedCancerType}
                             userData={userData}
                         />

--- a/src/data/CancerTypes.js
+++ b/src/data/CancerTypes.js
@@ -92,7 +92,8 @@ const CancerTypes = [
                         name: 'triple negative',
                         value: 'triplenegative',
                     },
-                ]
+                ],
+                showToPatient: true,
             }
         ],
         hasCalculator: true,
@@ -300,7 +301,8 @@ const CancerTypes = [
                         name: 'non-small cell carcinoma',
                         value: 'nonsmallcellcarcinoma',
                     },
-                ]
+                ],
+                showToPatient: true,
             }
         ],
         hasCalculator: true,
@@ -577,7 +579,8 @@ const CancerTypes = [
                         name: 'germ type',
                         value: 'germtype',
                     },
-                ]
+                ],
+                showToPatient: true,
             }
         ],
         hasCalculator: true,
@@ -630,7 +633,8 @@ const CancerTypes = [
                         name: 'poorly differentiated',
                         value: 'poorly',
                     },
-                ]
+                ],
+                showToPatient: false,
             }
         ],
         hasCalculator: true,
@@ -819,7 +823,8 @@ const CancerTypes = [
                         name: 'leiomyosarcoma',
                         value: 'leiomyosarcoma',
                     },
-                ]
+                ],
+                showToPatient: true,
             }
         ],
         hasCalculator: true,


### PR DESCRIPTION
This PR allows "extra variable" questions to be hidden from the patient view. In the CancerTypes data file, one of the keys of each "extra variable" question is `showToPatient`. In all cases I set it to be `true` except for the Gleason Score question of Prostate Cancer, so you can check it out.

Basically, if that is set to "false" then the patient view will never show the question.