### PR TITLE
Change query-string version to 5.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ csr.sublime-workspace
 node_modules/
 package-lock.json
 build/
+build/*.svg
+build/assets/*.svg

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 csr.sublime-workspace
 node_modules/
 package-lock.json
+build/

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "informed": "1.10.4",
     "is-mobile": "1.0.0",
     "prop-types": "15.6.2",
-    "query-string": "6.2.0",
+    "query-string": "5.1.1",
     "rc-slider": "8.6.1",
     "react": "16.3.0",
     "react-copy-to-clipboard": "5.0.1",


### PR DESCRIPTION
This should resolve the `uglify.js` issues. Try switching to this branch (`merges.use-older-query-string`) and then run:

- `npm cache clean`
- `npm install`
- `npm run build`

An older verison of `query-string` should be installed (5.1.1 instead of 6.2.0). This older version should still work just fine, but the webpack build should now succeed.